### PR TITLE
Updated Package.swift to work with swift-tools 5.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "8623e73b193386909566a9ca20203e33a09af142",
           "version": "4.5.0"
         }
+      },
+      {
+        "package": "Zip",
+        "repositoryURL": "https://github.com/marmelroy/Zip",
+        "state": {
+          "branch": null,
+          "revision": "80b1c3005ee25b4c7ce46c4029ac3347e8d5e37e",
+          "version": "2.0.0"
+        }
       }
     ]
   },

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "AEXML",
+        "repositoryURL": "https://github.com/tadija/AEXML",
+        "state": {
+          "branch": null,
+          "revision": "8623e73b193386909566a9ca20203e33a09af142",
+          "version": "4.5.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:5.2
+
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,17 @@ let package = Package(
         .library(name: "EPUBKit", targets: ["EPUBKit"]),
     ],
     
-    dependencies: [.package(url: "https://github.com/tadija/AEXML", from: "4.5.0")],
+    dependencies: [
+        .package(
+            url: "https://github.com/tadija/AEXML",
+            from: "4.5.0"),
+        .package(url: "https://github.com/marmelroy/Zip", from: "2.0.0")
+    ],
     
     targets: [
         .target(
             name: "EPUBKit",
-            dependencies: ["AEXML"],
+            dependencies: ["AEXML", "Zip"],
             path: "Sources"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,13 @@ let package = Package(
         .library(name: "EPUBKit", targets: ["EPUBKit"]),
     ],
     
+    dependencies: [.package(url: "https://github.com/tadija/AEXML", from: "4.5.0")],
+    
     targets: [
         .target(
             name: "EPUBKit",
-            path: "Sources")
+            dependencies: ["AEXML"],
+            path: "Sources"
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,5 +3,21 @@
 import PackageDescription
 
 let package = Package(
-    name: "EPUBKit"
+    name: "EPUBKit",
+    
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v9),
+        .tvOS(.v9)
+    ],
+    
+    products: [
+        .library(name: "EPUBKit", targets: ["EPUBKit"]),
+    ],
+    
+    targets: [
+        .target(
+            name: "EPUBKit",
+            path: "Sources")
+    ]
 )


### PR DESCRIPTION
This pull request enables Xcode 11 to add EPUBKit as package dependency